### PR TITLE
Add a github action to run the standard linter against the repository in each branch

### DIFF
--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -1,0 +1,12 @@
+name: StandardRB
+
+on: [push]
+
+jobs:
+  StandardRB:
+    runs-on: ubuntu-latest
+    steps:
+      - name: standardrb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: amoeba/standardrb-action@v2

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -6,6 +6,8 @@ jobs:
   StandardRB:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: StandardRB Linter
         uses: andrewmcodes/standardrb-action@v1.0.0
         env:

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -6,7 +6,7 @@ jobs:
   StandardRB:
     runs-on: ubuntu-latest
     steps:
-      - name: standardrb
+      - name: StandardRB Linter
+        uses: andrewmcodes/standardrb-action@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: amoeba/standardrb-action@v2


### PR DESCRIPTION
Enforce the standard styleguide with an action that can set commit statuses and provide annotations. Here's what it looks like when there are violations in a PR/diff: [link](https://github.com/nevinera/environment_helpers/compare/eriq--add-gha-for-standardrb--with-problems).

That link probably won't work in a few days, so here's a screenshot: 
<img width="1188" alt="Screenshot 2023-04-24 at 3 23 14 PM" src="https://user-images.githubusercontent.com/366133/234095568-694afa09-68e6-41e0-a941-a282a13db7c8.png">
