### PR TITLE
Enforce test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .ruby-gemset
 Gemfile.lock
 *.gem
+coverage/

--- a/environment_helpers.gemspec
+++ b/environment_helpers.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rspec", ">= 3.10"
+  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "rubocop"

--- a/lib/environment_helpers/boolean_helpers.rb
+++ b/lib/environment_helpers/boolean_helpers.rb
@@ -10,7 +10,6 @@ module EnvironmentHelpers
       check_default_value(:boolean, default, allow: [nil, true, false])
       text = fetch_value(name, required: required)
 
-      return default if text.nil?
       return true if truthy_text?(text)
       return false if falsey_text?(text)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,12 @@
 require "rspec"
 
+if ENV["SIMPLECOV"] || ENV["CI"]
+  require "simplecov"
+  SimpleCov.start do
+    enable_coverage :branch
+  end
+end
+
 require File.expand_path("../../lib/environment_helpers", __FILE__)
 gem_root = File.expand_path("../..", __FILE__)
 support_glob = File.join(gem_root, "spec", "support", "**", "*.rb")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ if ENV["SIMPLECOV"] || ENV["CI"]
   SimpleCov.start do
     enable_coverage :branch
   end
+
+  SimpleCov.minimum_coverage line: 100, branch: 100
 end
 
 require File.expand_path("../../lib/environment_helpers", __FILE__)


### PR DESCRIPTION
Resolves #3 

For now, we're going to enforce 100% line and branch coverage. In an application that's generally a bad idea, but for a shallow/flat gem like this one, it's _probably_ supportable.. But we might change that later, if it turns out that it keeps us from writing code defensively, for example.