### PR TITLE
Support `ENV.date` helper method

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,7 +3,7 @@ name: RSpec
 on: [push]
 
 jobs:
-  StandardRB:
+  RSpec:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ENV.string("APP_NAME", default: "local")
 ENV.symbol("BUSINESS_DOMAIN", default: :engineering, required: true)
 ENV.boolean("ENABLE_FEATURE_FOO", default: false)
 ENV.integer("MAX_THREAD_COUNT", default: 5)
+ENV.date("SCHEDULED_DATE", required: true, format: "%Y-%m-%d")
 ```
 
 Each of the supplied methods takes a positional parameter for the name of the environment variable,
@@ -53,3 +54,7 @@ The available methods added to `ENV`:
 * `integer` - produces an integer from the environment variable, by calling `to_i` on it (if it's
   present). Note that this means that providing a value like "hello" means you'll get `0`, since
   that's what ruby does when you call `"hello".to_i`.
+* `date` - produces a `Date` object, using `Date.strptime`. The default format string is `%Y-%m-%d`,
+  which would parse a date like `2023-12-25`. It will handle invalid values (or format strings) like
+  the variable not being present, though if it's specified as `required`, you will see a different
+  exception in each case.

--- a/lib/environment_helpers.rb
+++ b/lib/environment_helpers.rb
@@ -2,6 +2,7 @@ require_relative "./environment_helpers/access_helpers"
 require_relative "./environment_helpers/string_helpers"
 require_relative "./environment_helpers/boolean_helpers"
 require_relative "./environment_helpers/numeric_helpers"
+require_relative "./environment_helpers/datetime_helpers"
 
 module EnvironmentHelpers
   Error = Class.new(::StandardError)
@@ -11,11 +12,13 @@ module EnvironmentHelpers
   InvalidValue = Class.new(Error)
   InvalidBooleanText = Class.new(InvalidValue)
   InvalidIntegerText = Class.new(InvalidValue)
+  InvalidDateText = Class.new(InvalidValue)
 
   include AccessHelpers
   include StringHelpers
   include BooleanHelpers
   include NumericHelpers
+  include DatetimeHelpers
 end
 
 ENV.extend(EnvironmentHelpers)

--- a/lib/environment_helpers/datetime_helpers.rb
+++ b/lib/environment_helpers/datetime_helpers.rb
@@ -1,0 +1,24 @@
+require "date"
+
+module EnvironmentHelpers
+  module DatetimeHelpers
+    def date(name, format: "%Y-%m-%d", default: nil, required: false)
+      check_default_type(:date, default, Date)
+      text = fetch_value(name, required: required)
+      date = parse_date_from(text, format: format)
+
+      return date if date
+      return default unless required
+      fail(InvalidDateText, "Required date environment variable #{name} had inappropriate content '#{text}'")
+    end
+
+    private
+
+    def parse_date_from(text, format:)
+      return nil if text.nil?
+      Date.strptime(text, format)
+    rescue Date::Error
+      nil
+    end
+  end
+end

--- a/lib/environment_helpers/datetime_helpers.rb
+++ b/lib/environment_helpers/datetime_helpers.rb
@@ -17,7 +17,7 @@ module EnvironmentHelpers
     def parse_date_from(text, format:)
       return nil if text.nil?
       Date.strptime(text, format)
-    rescue Date::Error
+    rescue ArgumentError
       nil
     end
   end

--- a/lib/environment_helpers/version.rb
+++ b/lib/environment_helpers/version.rb
@@ -1,3 +1,3 @@
 module EnvironmentHelpers
-  VERSION = "0.0.1"
+  VERSION = "1.0.0"
 end

--- a/spec/environment_helpers/datetime_helpers_spec.rb
+++ b/spec/environment_helpers/datetime_helpers_spec.rb
@@ -1,0 +1,95 @@
+RSpec.describe EnvironmentHelpers::DatetimeHelpers do
+  subject(:env) { ENV }
+
+  describe "#date" do
+    let(:name) { "FOO" }
+    let(:options) { {} }
+    subject(:date) { env.date(name, **options) }
+
+    context "with required: true" do
+      let(:options) { {required: true} }
+
+      context "when the environment value is not set" do
+        before { expect(ENV["FOO"]).to be_nil }
+
+        it "raises a MissingVariableError" do
+          expect { date }.to raise_error(
+            EnvironmentHelpers::MissingVariableError,
+            /not supplied/
+          )
+        end
+      end
+
+      context "when the environment value is set" do
+        with_env("FOO" => "2023-04-25")
+        it { is_expected.to eq(Date.new(2023, 4, 25)) }
+
+        context "to an invalid value" do
+          with_env("FOO" => "hello")
+
+          it "raises a MissingVariableError" do
+            expect { date }.to raise_error(
+              EnvironmentHelpers::InvalidDateText,
+              /inappropriate content/
+            )
+          end
+        end
+      end
+    end
+
+    context "with default set" do
+      let(:options) { {default: Date.new(2000, 1, 1)} }
+
+      context "to a value of the wrong type" do
+        let(:options) { {default: 5} }
+
+        it "raises a BadDefault error" do
+          expect { date }.to raise_error(
+            EnvironmentHelpers::BadDefault,
+            /inappropriate default/i
+          )
+        end
+      end
+
+      context "when the environment value is not set" do
+        before { expect(ENV["FOO"]).to be_nil }
+        it { is_expected.to eq(Date.new(2000, 1, 1)) }
+      end
+
+      context "when the environment value is set" do
+        with_env("FOO" => "2023-04-25")
+        it { is_expected.to eq(Date.new(2023, 4, 25)) }
+      end
+    end
+
+    context "with default not set" do
+      before { expect(options).not_to include(:default) }
+
+      context "when the environment value is not set" do
+        before { expect(ENV["FOO"]).to be_nil }
+        it { is_expected.to be_nil }
+      end
+
+      context "when the environment value is set" do
+        with_env("FOO" => "2023-04-25")
+        it { is_expected.to eq(Date.new(2023, 4, 25)) }
+      end
+    end
+
+    context "with other formats supplied" do
+      def self.it_parses_date_as(text:, format:, result:)
+        context "for supplied text '#{text}' and format '#{format}'" do
+          let(:options) { {format: format} }
+          with_env("FOO" => text)
+          it { is_expected.to eq(result) }
+        end
+      end
+
+      it_parses_date_as text: "2023-4-12", format: "%Y-%m-%d", result: Date.new(2023, 4, 12)
+      it_parses_date_as text: "2023/4/12", format: "%Y/%m/%d", result: Date.new(2023, 4, 12)
+      it_parses_date_as text: "1/2/3", format: "%m/%d/%Y", result: Date.new(3, 1, 2)
+      it_parses_date_as text: "hello", format: "%m/%d/%Y", result: nil
+      it_parses_date_as text: "2023-4-12", format: "hello", result: nil
+    end
+  end
+end


### PR DESCRIPTION
Resolves #4 

Support an `ENV.date` method, so that dates can be supplied easily via command-line. This is mostly useful in background chore-like tasks, when you need to specify some date-boundaries to limit the scope of the chore or task to "recent records" of some form, but can also be used to schedule things some time in the future (though not with great granularity). Supporting a zoned datetime might happen in the future, but I'd rather not worry about timezones yet, since we don't want to bring in ActiveSupport.