### PR TITLE
Add support for file paths. Returns a Pathname object

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ENV.string("APP_NAME", default: "local")
 ENV.symbol("BUSINESS_DOMAIN", default: :engineering, required: true)
 ENV.boolean("ENABLE_FEATURE_FOO", default: false)
 ENV.integer("MAX_THREAD_COUNT", default: 5)
+ENV.file_handle("FILE_PATH", default: "DEFAULT_PATH", required: true)
 ```
 
 Each of the supplied methods takes a positional parameter for the name of the environment variable,
@@ -44,6 +45,7 @@ isn't present in the environment. If `required` is set to a truthy value, then i
 present in the environment, an `EnvironmentHelpers::MissingVariableError` is raised.
 
 The available methods added to `ENV`:
+
 * `string` - environment values are already strings, so this is the simplest of the methods.
 * `symbol` - produces a symbol, and enforces that the default value is either `nil` or a Symbol.
 * `boolean` - produces `nil`, `true`, or `false` (and only allows those as defaults). Supports..
@@ -53,3 +55,4 @@ The available methods added to `ENV`:
 * `integer` - produces an integer from the environment variable, by calling `to_i` on it (if it's
   present). Note that this means that providing a value like "hello" means you'll get `0`, since
   that's what ruby does when you call `"hello".to_i`.
+* `file_handle` - produces a `Pathname` object if the path name given by the environment variable matches an existing path.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ENV.string("APP_NAME", default: "local")
 ENV.symbol("BUSINESS_DOMAIN", default: :engineering, required: true)
 ENV.boolean("ENABLE_FEATURE_FOO", default: false)
 ENV.integer("MAX_THREAD_COUNT", default: 5)
-ENV.file_handle("FILE_PATH", default: "DEFAULT_PATH", required: true)
+ENV.file_handle("FILE_PATH", default: "/some/path", required: true)
 ENV.date("SCHEDULED_DATE", required: true, format: "%Y-%m-%d")
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ methods onto `ENV` for your use.
 
 ## Usage
 
-```
+```shell
 ENV.string("APP_NAME", default: "local")
 ENV.symbol("BUSINESS_DOMAIN", default: :engineering, required: true)
 ENV.boolean("ENABLE_FEATURE_FOO", default: false)
@@ -59,7 +59,7 @@ The available methods added to `ENV`:
 * `integer` - produces an integer from the environment variable, by calling `to_i` on it (if it's
   present). Note that this means that providing a value like "hello" means you'll get `0`, since
   that's what ruby does when you call `"hello".to_i`.
-* `file_path` - produces a `Pathname` object if the path name given by the environment variable matches an existing path.
+* `file_path` - produces a `Pathname` initialized with the path specified by the environment variable.
 * `date` - produces a `Date` object, using `Date.strptime`. The default format string is `%Y-%m-%d`,
   which would parse a date like `2023-12-25`. It will handle invalid values (or format strings) like
   the variable not being present, though if it's specified as `required`, you will see a different

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ENV.symbol("BUSINESS_DOMAIN", default: :engineering, required: true)
 ENV.boolean("ENABLE_FEATURE_FOO", default: false)
 ENV.integer_range("ID_RANGE", default: (500..6000))
 ENV.integer("MAX_THREAD_COUNT", default: 5)
-ENV.file_handle("FILE_PATH", default: "/some/path", required: true)
+ENV.file_path("FILE_PATH", default: "/some/path", required: true)
 ENV.date("SCHEDULED_DATE", required: true, format: "%Y-%m-%d")
 ```
 
@@ -59,7 +59,7 @@ The available methods added to `ENV`:
 * `integer` - produces an integer from the environment variable, by calling `to_i` on it (if it's
   present). Note that this means that providing a value like "hello" means you'll get `0`, since
   that's what ruby does when you call `"hello".to_i`.
-* `file_handle` - produces a `Pathname` object if the path name given by the environment variable matches an existing path.
+* `file_path` - produces a `Pathname` object if the path name given by the environment variable matches an existing path.
 * `date` - produces a `Date` object, using `Date.strptime`. The default format string is `%Y-%m-%d`,
   which would parse a date like `2023-12-25`. It will handle invalid values (or format strings) like
   the variable not being present, though if it's specified as `required`, you will see a different

--- a/lib/environment_helpers.rb
+++ b/lib/environment_helpers.rb
@@ -2,6 +2,7 @@ require_relative "./environment_helpers/access_helpers"
 require_relative "./environment_helpers/string_helpers"
 require_relative "./environment_helpers/boolean_helpers"
 require_relative "./environment_helpers/numeric_helpers"
+require_relative "./environment_helpers/file_helpers"
 
 module EnvironmentHelpers
   Error = Class.new(::StandardError)
@@ -16,6 +17,7 @@ module EnvironmentHelpers
   include StringHelpers
   include BooleanHelpers
   include NumericHelpers
+  include FileHelpers
 end
 
 ENV.extend(EnvironmentHelpers)

--- a/lib/environment_helpers/file_helpers.rb
+++ b/lib/environment_helpers/file_helpers.rb
@@ -1,0 +1,14 @@
+require "pathname"
+
+module EnvironmentHelpers
+  module FileHelpers
+    def file_path(name, default: nil, required: false)
+      check_default_type(:file_path, default, String)
+      path = fetch_value(name, required: required) || default
+      return nil if path.nil?
+      Pathname.new(path).then do |pathname|
+        pathname.exist? ? pathname : nil
+      end
+    end
+  end
+end

--- a/lib/environment_helpers/file_helpers.rb
+++ b/lib/environment_helpers/file_helpers.rb
@@ -6,9 +6,7 @@ module EnvironmentHelpers
       check_default_type(:file_path, default, String)
       path = fetch_value(name, required: required) || default
       return nil if path.nil?
-      Pathname.new(path).then do |pathname|
-        pathname.exist? ? pathname : nil
-      end
+      Pathname.new(path)
     end
   end
 end

--- a/lib/environment_helpers/version.rb
+++ b/lib/environment_helpers/version.rb
@@ -1,3 +1,3 @@
 module EnvironmentHelpers
-  VERSION = "1.0.2"
+  VERSION = "1.2.0"
 end

--- a/lib/environment_helpers/version.rb
+++ b/lib/environment_helpers/version.rb
@@ -1,3 +1,3 @@
 module EnvironmentHelpers
-  VERSION = "0.0.1"
+  VERSION = "1.1.0"
 end

--- a/spec/environment_helpers/file_helpers_spec.rb
+++ b/spec/environment_helpers/file_helpers_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe EnvironmentHelpers::FileHelpers do
       context "when the environment value is set" do
         context "but it does not point to an existing file" do
           with_env("FOO" => "bar")
-          it { is_expected.to be_nil }
+          it { is_expected.to eq Pathname.new("bar") }
         end
 
-        context "but it does not point to an existing file" do
+        context "and it points to an existing file" do
           with_env("FOO" => __FILE__)
           it { is_expected.to eq Pathname.new(__FILE__) }
         end
@@ -39,7 +39,7 @@ RSpec.describe EnvironmentHelpers::FileHelpers do
       context "when the environment value is set" do
         context "to a pathname that does not exist" do
           with_env("FOO" => "bar")
-          it { is_expected.to be_nil }
+          it { is_expected.to eq Pathname.new("bar") }
         end
 
         context "to a pathname that does exist" do
@@ -53,13 +53,13 @@ RSpec.describe EnvironmentHelpers::FileHelpers do
       subject(:file_path) { ENV.file_path(name, default: "foo") }
 
       context "when the environment value is not set" do
-        it { is_expected.to be_nil }
+        it { is_expected.to eq Pathname.new("foo") }
       end
 
       context "when the environment value is set" do
         context "to a pathname that does not exist" do
           with_env("FOO" => "bar")
-          it { is_expected.to be_nil }
+          it { is_expected.to eq Pathname.new("bar") }
         end
 
         context "to a pathname that does exist" do

--- a/spec/environment_helpers/file_helpers_spec.rb
+++ b/spec/environment_helpers/file_helpers_spec.rb
@@ -16,15 +16,8 @@ RSpec.describe EnvironmentHelpers::FileHelpers do
       end
 
       context "when the environment value is set" do
-        context "but it does not point to an existing file" do
-          with_env("FOO" => "bar")
-          it { is_expected.to eq Pathname.new("bar") }
-        end
-
-        context "and it points to an existing file" do
-          with_env("FOO" => __FILE__)
-          it { is_expected.to eq Pathname.new(__FILE__) }
-        end
+        with_env("FOO" => "bar")
+        it { is_expected.to eq Pathname.new("bar") }
       end
     end
 
@@ -37,15 +30,8 @@ RSpec.describe EnvironmentHelpers::FileHelpers do
       end
 
       context "when the environment value is set" do
-        context "to a pathname that does not exist" do
-          with_env("FOO" => "bar")
-          it { is_expected.to eq Pathname.new("bar") }
-        end
-
-        context "to a pathname that does exist" do
-          with_env("FOO" => __FILE__)
-          it { is_expected.to eq Pathname.new(__FILE__) }
-        end
+        with_env("FOO" => "bar")
+        it { is_expected.to eq Pathname.new("bar") }
       end
     end
 
@@ -57,15 +43,8 @@ RSpec.describe EnvironmentHelpers::FileHelpers do
       end
 
       context "when the environment value is set" do
-        context "to a pathname that does not exist" do
-          with_env("FOO" => "bar")
-          it { is_expected.to eq Pathname.new("bar") }
-        end
-
-        context "to a pathname that does exist" do
-          with_env("FOO" => __FILE__)
-          it { is_expected.to eq Pathname.new(__FILE__) }
-        end
+        with_env("FOO" => "bar")
+        it { is_expected.to eq Pathname.new("bar") }
       end
     end
   end

--- a/spec/environment_helpers/file_helpers_spec.rb
+++ b/spec/environment_helpers/file_helpers_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe EnvironmentHelpers::FileHelpers do
+  subject(:env) { ENV }
+
+  describe "#file_path" do
+    let(:name) { "FOO" }
+
+    context "with required: true" do
+      subject(:file_path) { ENV.file_path(name, required: true) }
+
+      context "when the environment value is not set" do
+        before { expect(ENV["FOO"]).to be_nil }
+
+        it "raises a MissingVariableError" do
+          expect { file_path }.to raise_error(EnvironmentHelpers::MissingVariableError, /not supplied/)
+        end
+      end
+
+      context "when the environment value is set" do
+        context "but it does not point to an existing file" do
+          with_env("FOO" => "bar")
+          it { is_expected.to be_nil }
+        end
+
+        context "but it does not point to an existing file" do
+          with_env("FOO" => __FILE__)
+          it { is_expected.to eq Pathname.new(__FILE__) }
+        end
+      end
+    end
+
+    context "without a default specified" do
+      subject(:file_path) { ENV.file_path(name) }
+
+      context "when the environment value is not set" do
+        before { expect(ENV["FOO"]).to be_nil }
+        it { is_expected.to be_nil }
+      end
+
+      context "when the environment value is set" do
+        context "to a pathname that does not exist" do
+          with_env("FOO" => "bar")
+          it { is_expected.to be_nil }
+        end
+
+        context "to a pathname that does exist" do
+          with_env("FOO" => __FILE__)
+          it { is_expected.to eq Pathname.new(__FILE__) }
+        end
+      end
+    end
+
+    context "with a default specified" do
+      subject(:file_path) { ENV.file_path(name, default: "foo") }
+
+      context "when the environment value is not set" do
+        it { is_expected.to be_nil }
+      end
+
+      context "when the environment value is set" do
+        context "to a pathname that does not exist" do
+          with_env("FOO" => "bar")
+          it { is_expected.to be_nil }
+        end
+
+        context "to a pathname that does exist" do
+          with_env("FOO" => __FILE__)
+          it { is_expected.to eq Pathname.new(__FILE__) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to parse a `Pathname` object if given an existing file path:

```ruby
  path = ENV.file_handle("PATH_NAME", default: "DEFAULT_PATH", required: true)
  <Pathname:path>
```

Resolves https://github.com/nevinera/environment_helpers/issues/13