### PR TITLE
Require 'set' before loading the gem

### DIFF
--- a/lib/environment_helpers.rb
+++ b/lib/environment_helpers.rb
@@ -1,4 +1,6 @@
-require "set"
+# 'set' doesn't need requiring after ruby 3.2, but it won't hurt anything.
+# And we're compatible back to 2.6
+require "set" # rubocop:disable Lint/RedundantRequireStatement
 
 require_relative "./environment_helpers/access_helpers"
 require_relative "./environment_helpers/string_helpers"

--- a/lib/environment_helpers.rb
+++ b/lib/environment_helpers.rb
@@ -1,3 +1,5 @@
+require "set"
+
 require_relative "./environment_helpers/access_helpers"
 require_relative "./environment_helpers/string_helpers"
 require_relative "./environment_helpers/boolean_helpers"

--- a/lib/environment_helpers/version.rb
+++ b/lib/environment_helpers/version.rb
@@ -1,3 +1,3 @@
 module EnvironmentHelpers
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
I think this is masked because _practically every other_ library also requires Set, including things like IRB. So it's hard to tell when Set isn't loaded initially, but it definitely needs requiring until ruby 3.2: [link](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantRequireStatement)