### PR TITLE
Add ENV.array environment helper

### DIFF
--- a/lib/environment_helpers.rb
+++ b/lib/environment_helpers.rb
@@ -9,6 +9,7 @@ require_relative "./environment_helpers/range_helpers"
 require_relative "./environment_helpers/numeric_helpers"
 require_relative "./environment_helpers/file_helpers"
 require_relative "./environment_helpers/datetime_helpers"
+require_relative "./environment_helpers/enumerable_helpers"
 
 module EnvironmentHelpers
   Error = Class.new(::StandardError)
@@ -16,6 +17,7 @@ module EnvironmentHelpers
   BadDefault = Class.new(Error)
   BadFormat = Class.new(Error)
 
+  InvalidType = Class.new(Error)
   InvalidValue = Class.new(Error)
   InvalidBooleanText = Class.new(InvalidValue)
   InvalidRangeText = Class.new(InvalidValue)
@@ -30,6 +32,7 @@ module EnvironmentHelpers
   include NumericHelpers
   include FileHelpers
   include DatetimeHelpers
+  include EnumerableHelpers
 end
 
 ENV.extend(EnvironmentHelpers)

--- a/lib/environment_helpers/enumerable_helpers.rb
+++ b/lib/environment_helpers/enumerable_helpers.rb
@@ -1,31 +1,44 @@
 module EnvironmentHelpers
   module EnumerableHelpers
-    VALID_TYPES = %i[strings symbols integers file_paths]
+    VALID_TYPES = %i[strings symbols integers]
 
     def array(key, of: :strings, delimiter: ",", default: nil, required: false)
       check_default_type(:array, default, Array)
-      check_valid_data_type(of)
+      check_valid_data_type!(of)
+      check_default_data_types!(default, of)
 
       values = fetch_value(key, required: required)
       return default if values.nil?
-      values.split(delimiter).map do |value|
-        TYPE_HANDLERS[of].call(value)
-      end
+
+      values.split(delimiter).map { |value| value.send(TYPE_HANDLERS[of]) }
     end
 
     private
 
-    def check_valid_data_type(type)
+    def check_valid_data_type!(type)
       unless VALID_TYPES.include?(type)
         fail(InvalidType, "Valid types: #{VALID_TYPES.join(", ")}. Got: #{type}.")
       end
     end
 
+    def check_default_data_types!(default, type)
+      invalid = Array(default).reject { |val| val.is_a? TYPE_MAP[type] }
+
+      unless invalid.empty?
+        fail(BadDefault, "Default array contains values not of type `#{type}': #{invalid.join(", ")}")
+      end
+    end
+
     TYPE_HANDLERS = {
-      strings: ->(value) { value.to_s },
-      symbols: ->(value) { value.to_sym },
-      integers: ->(value) { value.to_i },
-      file_paths: ->(value) { Pathname.new(value) }
+      integers: :to_i,
+      strings: :to_s,
+      symbols: :to_sym
+    }
+
+    TYPE_MAP = {
+      integers: Integer,
+      strings: String,
+      symbols: Symbol
     }
   end
 end

--- a/lib/environment_helpers/enumerable_helpers.rb
+++ b/lib/environment_helpers/enumerable_helpers.rb
@@ -1,0 +1,31 @@
+module EnvironmentHelpers
+  module EnumerableHelpers
+    VALID_TYPES = %i[strings symbols integers file_paths]
+
+    def array(key, of: :strings, delimiter: ",", default: nil, required: false)
+      check_default_type(:array, default, Array)
+      check_valid_data_type(of)
+
+      values = fetch_value(key, required: required)
+      return default if values.nil?
+      values.split(delimiter).map do |value|
+        TYPE_HANDLERS[of].call(value)
+      end
+    end
+
+    private
+
+    def check_valid_data_type(type)
+      unless VALID_TYPES.include?(type)
+        fail(InvalidType, "Valid types: #{VALID_TYPES.join(", ")}. Got: #{type}.")
+      end
+    end
+
+    TYPE_HANDLERS = {
+      strings: ->(value) { value.to_s },
+      symbols: ->(value) { value.to_sym },
+      integers: ->(value) { value.to_i },
+      file_paths: ->(value) { Pathname.new(value) }
+    }
+  end
+end

--- a/spec/environment_helpers/enumerable_helpers_spec.rb
+++ b/spec/environment_helpers/enumerable_helpers_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe EnvironmentHelpers::BooleanHelpers do
+RSpec.describe EnvironmentHelpers::EnumerableHelpers do
   subject(:env) { ENV }
 
   describe "#array" do
@@ -36,11 +36,6 @@ RSpec.describe EnvironmentHelpers::BooleanHelpers do
             expect { subject }.to raise_error(EnvironmentHelpers::InvalidType, /Valid types: .+\. Got: booleans\./)
           end
         end
-
-        context "when it is set to `file_paths'" do
-          let(:type) { :file_paths }
-          it { should eq [Pathname.new("a"), Pathname.new("bc"), Pathname.new("d")] }
-        end
       end
 
       context "when not passed an `of' param" do
@@ -53,13 +48,13 @@ RSpec.describe EnvironmentHelpers::BooleanHelpers do
         it { should eq %w[a b,c d] }
       end
 
-      context "when not passed a `delimeter' param" do
+      context "when not passed a `delimiter' param" do
         with_env "FOO" => "a;b,c;d"
         it { should eq %w[a;b c;d] }
       end
 
       context "when passed a default value" do
-        let(:params) { {default: [42]} }
+        let(:params) { {default: ["foo"]} }
 
         context "but there is a value present at the key" do
           with_env("FOO" => "a,b,c")
@@ -68,7 +63,7 @@ RSpec.describe EnvironmentHelpers::BooleanHelpers do
 
         context "and there is not a value present at the key" do
           let(:env_var) { "FOOBAR" }
-          it { should eq [42] }
+          it { should eq ["foo"] }
         end
 
         context "but it is of the wrong type" do
@@ -76,6 +71,14 @@ RSpec.describe EnvironmentHelpers::BooleanHelpers do
 
           it "raises an error" do
             expect { subject }.to raise_error(EnvironmentHelpers::BadDefault)
+          end
+        end
+
+        context "but it contains values of the incorrect type" do
+          let(:params) { {default: ["a", 42, :foo, "b"]} }
+
+          it "raises an error" do
+            expect { subject }.to raise_error(EnvironmentHelpers::BadDefault, /contains values not of type `strings': 42, foo/)
           end
         end
       end

--- a/spec/environment_helpers/enumerable_helpers_spec.rb
+++ b/spec/environment_helpers/enumerable_helpers_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe EnvironmentHelpers::BooleanHelpers do
+  subject(:env) { ENV }
+
+  describe "#array" do
+    let(:params) { {} }
+    let(:env_var) { "FOO" }
+    subject(:array) { env.array(env_var, **params) }
+
+    with_env "FOO" => "a,bc,d"
+
+    describe "parameters" do
+      context "when passed an `of' param" do
+        let(:params) { {of: type} }
+
+        context "when it is set to `strings'" do
+          let(:type) { :strings }
+          it { should eq %w[a bc d] }
+        end
+
+        context "when it is set to `symbols'" do
+          let(:type) { :symbols }
+          it { should eq %i[a bc d] }
+        end
+
+        context "when it is set to `integers'" do
+          let(:type) { :integers }
+          with_env "FOO" => "1,2,3"
+          it { should eq [1, 2, 3] }
+        end
+
+        context "when it is set to an unsupported type" do
+          let(:type) { :booleans }
+          with_env "FOO" => "1,2,3"
+
+          it "raises an error" do
+            expect { subject }.to raise_error(EnvironmentHelpers::InvalidType, /Valid types: .+\. Got: booleans\./)
+          end
+        end
+
+        context "when it is set to `file_paths'" do
+          let(:type) { :file_paths }
+          it { should eq [Pathname.new("a"), Pathname.new("bc"), Pathname.new("d")] }
+        end
+      end
+
+      context "when not passed an `of' param" do
+        it { should eq %w[a bc d] }
+      end
+
+      context "when passed a `delimiter' param" do
+        let(:params) { {delimiter: ";"} }
+        with_env "FOO" => "a;b,c;d"
+        it { should eq %w[a b,c d] }
+      end
+
+      context "when not passed a `delimeter' param" do
+        with_env "FOO" => "a;b,c;d"
+        it { should eq %w[a;b c;d] }
+      end
+
+      context "when passed a default value" do
+        let(:params) { {default: [42]} }
+
+        context "but there is a value present at the key" do
+          with_env("FOO" => "a,b,c")
+          it { should eq %w[a b c] }
+        end
+
+        context "and there is not a value present at the key" do
+          let(:env_var) { "FOOBAR" }
+          it { should eq [42] }
+        end
+
+        context "but it is of the wrong type" do
+          let(:params) { {default: 42} }
+
+          it "raises an error" do
+            expect { subject }.to raise_error(EnvironmentHelpers::BadDefault)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Purpose

Allow for passing enumerable data in a delimited format. Data can be converted to string, symbol, integer, or path. Other types (boolean, etc) were a bit more complex, so I've deferred implementing them.

```ruby
❯ ADDRESSES=a,bc,d,e irb -r environment_helpers
>> ENV.array("ADDRESSES", of: :symbols, required: true, default: [4])
=> [:a, :bc, :d, :e]
>> ENV.array("ADDRESSES", of: :strings, required: true, default: [4])
=> ["a", "bc", "d", "e"]
>> ENV.array("ADDRESSES", of: :file_paths, required: true, default: [4])
=> [#<Pathname:a>, #<Pathname:bc>, #<Pathname:d>, #<Pathname:e>]
>> ENV.array("ADDRESSES", of: :integers, required: true, default: [4])
=> [0, 0, 0, 0]

❯ ADDRESSES="a;b,c;d,e" irb -r environment_helpers
>> ENV.array("ADDRESSES", of: :strings, delimiter: ";", required: true, default: [4])
=> ["a", "b,c", "d,e"]
```

Resolves https://github.com/nevinera/environment_helpers/issues/20