### PR TITLE
install and setup rspec-cover_it

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,8 +19,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
-          rubygems: latest
-          bundler: none
+
+      - name: Install gems
+        run: bundle install --jobs 4 --retry 3
 
       - name: Run QuietQuality
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,5 +24,5 @@ jobs:
 
       - name: Run QuietQuality
         run: |
-          gem install quiet_quality
+          gem install quiet_quality standard rubocop
           qq -C .quiet_quality.ci-cd.yml

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', 'head']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head']
 
     steps:
       - uses: actions/checkout@v3

--- a/environment_helpers.gemspec
+++ b/environment_helpers.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/nevinera/environment_helpers"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/environment_helpers.gemspec
+++ b/environment_helpers.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
+  spec.add_development_dependency "rspec-cover_it", "~> 0.1.0"
   spec.add_development_dependency "pry", "~> 0.14"
   spec.add_development_dependency "standard", "~> 1.28"
   spec.add_development_dependency "rubocop", "~> 1.50"

--- a/environment_helpers.gemspec
+++ b/environment_helpers.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.14"
   spec.add_development_dependency "standard", "~> 1.28"
   spec.add_development_dependency "rubocop", "~> 1.50"
+  spec.add_development_dependency "quiet_quality", "~> 1.3.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "rspec"
+require "rspec/cover_it"
 
 if ENV["SIMPLECOV"] || ENV["CI"]
   require "simplecov"
@@ -9,8 +10,10 @@ if ENV["SIMPLECOV"] || ENV["CI"]
   SimpleCov.minimum_coverage line: 100, branch: 100
 end
 
-require File.expand_path("../../lib/environment_helpers", __FILE__)
 gem_root = File.expand_path("../..", __FILE__)
+RSpec::CoverIt.setup(filter: gem_root, autoenforce: true)
+
+require File.expand_path("../../lib/environment_helpers", __FILE__)
 support_glob = File.join(gem_root, "spec", "support", "**", "*.rb")
 Dir[support_glob].sort.each { |f| require f }
 


### PR DESCRIPTION
Add a better form of coverage enforcement, and then satisfy it. We'll enforce coverage on all tested classes, and expect 100% coverage.

Drop support for ruby 2.6 (and start using bundler to install quiet_quality in GHA, since that was the blocker before).