### PR TITLE
Instead of constants, read the lists of truthy/falsey strings from env

### DIFF
--- a/lib/environment_helpers/boolean_helpers.rb
+++ b/lib/environment_helpers/boolean_helpers.rb
@@ -1,7 +1,5 @@
 module EnvironmentHelpers
   module BooleanHelpers
-    TRUTHY_STRINGS = %w[true yes on enabled enable allow t y 1 ok okay].to_set
-    FALSEY_STRINGS = %w[false no off disabled disable deny f n 0 nope].to_set
     BOOLEAN_VALUES = [true, false, nil].to_set
 
     def boolean(name, default: nil, required: false)
@@ -19,12 +17,26 @@ module EnvironmentHelpers
 
     def truthy_text?(text)
       return false if text.nil?
-      TRUTHY_STRINGS.include?(text.strip.downcase)
+      truthy_strings.include?(text.strip.downcase)
     end
 
     def falsey_text?(text)
       return false if text.nil?
-      FALSEY_STRINGS.include?(text.strip.downcase)
+      falsey_strings.include?(text.strip.downcase)
+    end
+
+    def truthy_strings
+      @_truthy_strings ||=
+        ENV.fetch("ENVIRONMENT_HELPERS_TRUTHY_STRINGS", "true,yes,on,enabled,enable,allow,t,y,1,ok,okay")
+          .split(",")
+          .to_set
+    end
+
+    def falsey_strings
+      @_falsey_strings ||=
+        ENV.fetch("ENVIRONMENT_HELPERS_FALSEY_STRINGS", "false,no,off,disabled,disable,deny,f,n,0,nope")
+          .split(",")
+          .to_set
     end
   end
 end

--- a/sig/environment_helpers.rbs
+++ b/sig/environment_helpers.rbs
@@ -71,12 +71,12 @@ module EnvironmentHelpers
   end
 
   module BooleanHelpers : AccessHelpers
-    TRUTHY_STRINGS: Set[String]
-    FALSEY_STRINGS: Set[String]
     BOOLEAN_VALUES: Set[bool]
     def boolean: (String name, default: bool?, required: bool) -> boolish
     private def truthy_text?: (String?) -> boolish
     private def falsey_text?: (String?) -> boolish
+    private def truthy_strings: () -> Set[String]
+    private def falsey_strings: () -> Set[String]
   end
 
   module EnumerableHelpers : AccessHelpers

--- a/spec/environment_helpers/boolean_helpers_spec.rb
+++ b/spec/environment_helpers/boolean_helpers_spec.rb
@@ -5,27 +5,29 @@ RSpec.describe EnvironmentHelpers::BooleanHelpers do
     let(:name) { "FOO" }
     let(:options) { {} }
     subject(:boolean) { env.boolean(name, **options) }
+    without_env "ENVIRONMENT_HELPERS_TRUTHY_STRINGS", "ENVIRONMENT_HELPERS_FALSEY_STRINGS"
 
-    described_class::TRUTHY_STRINGS.each do |text|
+    def self.it_handles(text, as:)
       context "when handling environment value '#{text}'" do
         with_env("FOO" => text)
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(as) }
       end
     end
 
-    described_class::FALSEY_STRINGS.each do |text|
-      context "when handling environment value '#{text}'" do
-        with_env("FOO" => text)
-        it { is_expected.to eq(false) }
-      end
+    %w[true yes on enabled enable allow t y 1 ok okay].each { |text| it_handles(text, as: true) }
+    %w[false no off disabled disable deny f n 0 nope].each { |text| it_handles(text, as: false) }
+
+    context "if not required" do
+      let(:options) { {default: true} }
+      ["meh", "maybe", "?", "tru", "!"].each { |text| it_handles(text, as: true) }
     end
 
-    ["meh", "maybe", "?", "tru", "!"].each do |text|
-      context "when handling environment value '#{text}'" do
-        with_env("FOO" => text)
+    context "if required" do
+      let(:options) { {required: true} }
 
-        context "if required" do
-          let(:options) { {required: true} }
+      ["meh", "maybe", "?", "tru", "!"].each do |text|
+        context "when handling environment value '#{text}'" do
+          with_env("FOO" => text)
 
           it "raises InvalidBooleanText" do
             expect { boolean }.to raise_error(
@@ -34,11 +36,43 @@ RSpec.describe EnvironmentHelpers::BooleanHelpers do
             )
           end
         end
+      end
+    end
 
-        context "if not required" do
-          let(:options) { {default: true} }
-          it { is_expected.to eq(true) }
-        end
+    context "with ENVIRONMENT_HELPERS_TRUTHY_STRINGS supplied" do
+      before { ENV.instance_variable_set(:@_truthy_strings, nil) }
+      after { ENV.instance_variable_set(:@_truthy_strings, nil) }
+      let(:options) { {default: false} }
+      with_env "ENVIRONMENT_HELPERS_TRUTHY_STRINGS" => "foo,bar,baz"
+      %w[foo bar baz].each { |text| it_handles(text, as: true) }
+      %w[true yes false no off].each { |text| it_handles(text, as: false) }
+    end
+
+    context "with ENVIRONMENT_HELPERS_FALSEY_STRINGS supplied" do
+      before { ENV.instance_variable_set(:@_falsey_strings, nil) }
+      after { ENV.instance_variable_set(:@_falsey_strings, nil) }
+      let(:options) { {default: true} }
+      with_env "ENVIRONMENT_HELPERS_FALSEY_STRINGS" => "foo,bar,baz"
+      %w[foo bar baz].each { |text| it_handles(text, as: false) }
+      %w[true yes false no off].each { |text| it_handles(text, as: true) }
+    end
+
+    context "with both FOO and BAR set" do
+      with_env "FOO" => "nope", "BAR" => "no", "BAZ" => "deny"
+
+      it "caches the values of truthy_strings and falsey_strings across ENV.boolean calls" do
+        allow(ENV).to receive(:fetch).and_call_original
+        ENV.instance_variable_set(:@_falsey_strings, nil)
+        ENV.instance_variable_set(:@_truthy_strings, nil)
+
+        ENV.boolean("BAR", required: false)
+        expect(ENV).to have_received(:fetch).with("ENVIRONMENT_HELPERS_TRUTHY_STRINGS", anything).once
+        expect(ENV).to have_received(:fetch).with("ENVIRONMENT_HELPERS_FALSEY_STRINGS", anything).once
+
+        ENV.boolean("FOO", required: false)
+        ENV.boolean("BAZ", required: false)
+        expect(ENV).to have_received(:fetch).with("ENVIRONMENT_HELPERS_TRUTHY_STRINGS", anything).once
+        expect(ENV).to have_received(:fetch).with("ENVIRONMENT_HELPERS_FALSEY_STRINGS", anything).once
       end
     end
 


### PR DESCRIPTION
And memoize those lists, since they can't change between invocations. Though it does make the specs somewhat gnarly (we need to de-memoize them for those tests).

The list of accepted strings is oddly contentious, and it's blocking adoption in places. Rather than battle out exactly which strings should be fuzzily acceptable as meaning which boolean values, we should just let them be supplied by the context. And if you're using this gem at all, you're probably happy to supply configuration via env. :-)

Despite the awkwardness of the resulting tests, I memoized the `truthy_strings` and `falsey_strings` methods - they shouldn't change during execution in a normal context, and they're substantial enough to be worth memoizing.