### PR TITLE
use checkout@v4

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,7 +7,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,7 +13,7 @@ jobs:
       NO_STEEP: "Because we need to test on versions that are older than steep supports"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This should produce no actual change for us:
https://github.com/actions/checkout/compare/v3.6.0...v4.1.1