### PR TITLE
Release `environment_helpers` 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Release 1.5.0
+
+* Add rbs/steep, and enforce types in CI (.rbs file is exported as part
+  of the gem) (#28, resolves #21)
+* Support env-based customization of the truthy/falsey strings used by
+  `ENV.boolean` (#29, resolves #27)
+* Update github workflows to use checkout@v4 (which should have no real
+  impact on us, aside from staying current). (#30)
+* Update README to explain `ENV.array`
+
 ## Release 1.4.0
 
 * Drop support for ruby 2.6

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ ENV.integer("MAX_THREAD_COUNT", default: 5)
 ENV.file_path("FILE_PATH", default: "/some/path", required: true)
 ENV.date("SCHEDULED_DATE", required: true, format: "%Y-%m-%d")
 ENV.date_time("RUN_AT", required: true, default: DateTime.now)
+ENV.array("QUEUE_NAMES", of: :strings, required: false, default: ["high", "low"])
 ```
 
 Each of the supplied methods takes a positional parameter for the name of the
@@ -83,3 +84,17 @@ The available methods added to `ENV`:
   as a strptime format string (the `:unix` format is equivalent to the format
   string `"%s"`). It handles invalid or unparseable values like `ENV.date` does,
   in that they are treated as if not supplied.
+* `array` - produces an array of strings, symbols, or integers, depending on the
+  value of the `of` parameter. You can specify the delimiter using a `delimiter`
+  parameter (it defaults to a comma).
+
+## Configuration
+
+If you want to specify your own list of truthy/falsey strings, you can do that
+by setting either or both of these environment variables, supplying comma-
+separated (whitespace-free) strings:
+
+* `ENVIRONMENT_HELPERS_TRUTHY_STRINGS` - the default value used is
+  `true,yes,on,enabled,enable,allow,t,y,1,ok,okay`
+* `ENVIRONMENT_HELPERS_FALSEY_STRINGS` - the default value used is
+  `false,no,off,disabled,disable,deny,f,n,0,nope`

--- a/lib/environment_helpers/version.rb
+++ b/lib/environment_helpers/version.rb
@@ -1,3 +1,3 @@
 module EnvironmentHelpers
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end


### PR DESCRIPTION
* Update the readme to (a) cover the `ENV.array` method which was left out, and (b) explain the two new config envs you can set
* Update the changelog to describe the changes since 1.4.0
* Update the actual version to 1.5.0