### PR TITLE
Nev  fixes after steep review

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_WITHOUT: "typing"

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,17 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-
-      - name: Cache gems
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-rspec-${{ matrix.ruby-version }}-${{ hashFiles('Gemfile.lock') }}
-          restore-keys:
-            ${{ runner.os }}-rspec-${{ matrix.ruby-version }}-
-
-      - name: Install gems
-        run: bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Run RSpec
         run: bundle exec rspec

--- a/Steepfile
+++ b/Steepfile
@@ -7,11 +7,3 @@ target :lib do
   library "pathname"
   library "date"
 end
-
-target :test do
-  signature "sig"
-  check "test"
-  configure_code_diagnostics(D::Ruby.default)
-  library "pathname"
-  library "date"
-end

--- a/sig/environment_helpers.rbs
+++ b/sig/environment_helpers.rbs
@@ -36,8 +36,7 @@ module EnvironmentHelpers
 
   module AccessHelpers
     # (Actually provided by ENV, which these are all extended onto)
-    def fetch: (String name) -> String?
-             | (String name, String? default) -> String?
+    def fetch: (String name, ?String? default) -> String?
 
     private def fetch_value: (String name, required: bool) -> String?
     private def check_default_type: (String | Symbol context, untyped value, *Class types) -> void


### PR DESCRIPTION
I got a review on https://github.com/nevinera/environment_helpers/pull/28 after it merged that had some good points, and I wanted to go ahead and get them taken care of.

* The `:test` config in the Steepfile would be for a 'test/' directory, which we don't have. In general, RBS doesn't do much for rspec tests, since they are constructed as massive piles of anonymous metaprogrammed modules and classes (which don't have any type information).
* Use the `?Foo` syntax to specify the optional parameter to `fetch`, instead of listing multiple signatures (it's equivalent, but the former is clearer and better)
* Stop managing the bundler cache and gem installation ourselves in the rspec github workflows

(I also tried to use groups to manage the installation of the steep gem instead of an environment variable but.. failed. See [here](https://github.com/nevinera/environment_helpers/pull/28#discussion_r1398636562) for details)