### PR TITLE
Update standard and qq, and correct resulting failures

### DIFF
--- a/environment_helpers.gemspec
+++ b/environment_helpers.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.22.0"
   spec.add_development_dependency "rspec-cover_it", "~> 0.1.0"
   spec.add_development_dependency "pry", "~> 0.14"
-  spec.add_development_dependency "standard", "~> 1.28"
+  spec.add_development_dependency "standard", "~> 1.50"
   spec.add_development_dependency "rubocop", "~> 1.50"
-  spec.add_development_dependency "quiet_quality", "~> 1.3.0"
+  spec.add_development_dependency "quiet_quality", "~> 1.5"
   spec.add_development_dependency "mdl", "~> 0.12"
 end

--- a/spec/environment_helpers/range_helpers_spec.rb
+++ b/spec/environment_helpers/range_helpers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EnvironmentHelpers::RangeHelpers do
 
       context "and the key is supplied" do
         with_env("FOO" => "52-63")
-        it { is_expected.to eq((52..63)) }
+        it { is_expected.to eq(52..63) }
 
         context "but has invalid content" do
           with_env("FOO" => "hello")
@@ -42,7 +42,7 @@ RSpec.describe EnvironmentHelpers::RangeHelpers do
 
       context "when the environment variable is present" do
         with_env("FOO" => "58..61")
-        it { is_expected.to eq((58..61)) }
+        it { is_expected.to eq(58..61) }
       end
 
       context "when the environment variable is not present" do
@@ -78,34 +78,34 @@ RSpec.describe EnvironmentHelpers::RangeHelpers do
 
       context "when the environment variable is present" do
         with_env("FOO" => "58..62")
-        it { is_expected.to eq((58..62)) }
+        it { is_expected.to eq(58..62) }
 
         context "but not actually an integer" do
           with_env("FOO" => "hello")
-          it { is_expected.to eq((91..93)) }
+          it { is_expected.to eq(91..93) }
         end
       end
 
       context "when the environment variable is not present" do
         before { expect(ENV["FOO"]).to be_nil }
-        it { is_expected.to eq((91..93)) }
+        it { is_expected.to eq(91..93) }
       end
     end
 
     context "for various formats" do
       context "with a dash" do
         with_env("FOO" => "3-5")
-        it { is_expected.to eq((3..5)) }
+        it { is_expected.to eq(3..5) }
       end
 
       context "with two dots" do
         with_env("FOO" => "3..5")
-        it { is_expected.to eq((3..5)) }
+        it { is_expected.to eq(3..5) }
       end
 
       context "with three dots" do
         with_env("FOO" => "3...5")
-        it { is_expected.to eq((3...5)) }
+        it { is_expected.to eq(3...5) }
         it { is_expected.not_to be_cover(5) }
       end
 


### PR DESCRIPTION
It's been a little bit, and standard and quiet_quality have both moved in that time.

Pin them to (currently) up-to-date versions, and then fix all the resulting linter failures