### PR TITLE
Pin standard to 1.37.0

### DIFF
--- a/environment_helpers.gemspec
+++ b/environment_helpers.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.22.0"
   spec.add_development_dependency "rspec-cover_it", "~> 0.1.0"
   spec.add_development_dependency "pry", "~> 0.14"
-  spec.add_development_dependency "standard", "~> 1.28"
-  spec.add_development_dependency "rubocop", "~> 1.50"
+  spec.add_development_dependency "standard", "= 1.37.0"
+  spec.add_development_dependency "rubocop", "~> 1.63"
   spec.add_development_dependency "quiet_quality", "~> 1.3.0"
   spec.add_development_dependency "mdl", "~> 0.12"
 end


### PR DESCRIPTION
This is _not ideal_. But we need to keep supporting ruby 2.7, and the standard versions after this one no longer do so.

(We could probably unpin and stop listing standardrb as a development dependency, since we need to _run the specs_ at 2.7 but do not need to run standard on that ruby. But there's already a can of worms there around the versioning for _steep_, so I'm going to stop it here for now).