### PR TITLE
Update ENV.string to check the type on the "default"

### DIFF
--- a/lib/environment_helpers/string_helpers.rb
+++ b/lib/environment_helpers/string_helpers.rb
@@ -1,6 +1,7 @@
 module EnvironmentHelpers
   module StringHelpers
     def string(name, default: nil, required: false)
+      check_default_type(:string, default, String)
       fetch_value(name, required: required) || default
     end
 

--- a/spec/environment_helpers/string_helpers_spec.rb
+++ b/spec/environment_helpers/string_helpers_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe EnvironmentHelpers::StringHelpers do
         with_env("FOO" => "bar")
         it { is_expected.to eq("bar") }
       end
+
+      context "of the wrong type" do
+        subject(:string) { ENV.string(name, default: :foo) }
+
+        it "raises a BadDefault error" do
+          expect { string }.to raise_error(EnvironmentHelpers::BadDefault, /inappropriate default/i)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Every other method does, and this should too. This prevents on from accidentally `ENV.string("FOO", default: :bar)` or worse, `ENV.string("FOO", default: 55)`. Easy mistake to make, and you won't find out you did so until you need the default value -.-

Fixes #33