### PR TITLE
Handle non-conforming integer ENVs appropriately

### DIFF
--- a/lib/environment_helpers/numeric_helpers.rb
+++ b/lib/environment_helpers/numeric_helpers.rb
@@ -2,8 +2,20 @@ module EnvironmentHelpers
   module NumericHelpers
     def integer(name, default: nil, required: false)
       check_default_type(:integer, default, Integer)
-      text = fetch_value(name, required: required)
+      text = fetch_value(name, required: required)&.strip
+      text = enforced_format(text: text, required: required)
       text&.to_i || default
+    end
+
+    private
+
+    def enforced_format(text:, required:)
+      return nil unless text
+      return text if text.match?(/\A-?\d+\z/)
+
+      # Not a "correct" integer (we accept only limited forms here)
+      return nil unless required
+      fail(InvalidIntegerText, "The environment vaiable '${name}' contains text that does not look like an integer")
     end
   end
 end

--- a/spec/environment_helpers/numeric_helpers_spec.rb
+++ b/spec/environment_helpers/numeric_helpers_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe EnvironmentHelpers::NumericHelpers do
       context "and the key is supplied" do
         with_env("FOO" => "52")
         it { is_expected.to eq(52) }
+
+        context "with a whitespace-padded value" do
+          with_env("FOO" => "  52\t")
+          it { is_expected.to eq(52) }
+        end
+
+        context "with a non-integer value" do
+          with_env("FOO" => "1,000")
+
+          it "raises InvalidIntegerText" do
+            expect { integer }.to raise_error(
+              EnvironmentHelpers::InvalidIntegerText,
+              /does not look like an integer/
+            )
+          end
+        end
       end
 
       context "and the environment variable is not supplied" do
@@ -32,6 +48,16 @@ RSpec.describe EnvironmentHelpers::NumericHelpers do
       context "when the environment variable is present" do
         with_env("FOO" => "58")
         it { is_expected.to eq(58) }
+
+        context "with a whitespace-padded value" do
+          with_env("FOO" => "  52\t")
+          it { is_expected.to eq(52) }
+        end
+
+        context "with a non-integer value" do
+          with_env("FOO" => "1,000")
+          it { is_expected.to be_nil }
+        end
       end
 
       context "when the environment variable is not present" do
@@ -58,15 +84,19 @@ RSpec.describe EnvironmentHelpers::NumericHelpers do
         with_env("FOO" => "58")
         it { is_expected.to eq(58) }
 
-        context "but not actually an integer" do
-          # It produces "hello".to_i, which is zero.
-          with_env("FOO" => "hello")
-          it { is_expected.to eq(0) }
+        context "with a whitespace-padded value" do
+          with_env("FOO" => "  52\t")
+          it { is_expected.to eq(52) }
+        end
+
+        context "with a non-integer value" do
+          with_env("FOO" => "1,000")
+          it { is_expected.to eq(91) }
         end
       end
 
       context "when the environment variable is not present" do
-        before { expect(ENV["FOO"]).to be_nil }
+        without_env("FOO")
         it { is_expected.to eq(91) }
       end
     end


### PR DESCRIPTION
I must have _intended_ this behavior originally, because I defined EnvironmentHelpers::InvalidIntegerText quite a while ago. But nothing used it until now.

But going forward, `ENV.integer` will treat a _non-integer_ string much like one that isn't supplied in the ENV (except with a different error message, if it's `required`)