### PR TITLE
fix: do not use symlinks, nor include Gemfiles/locks in built gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Relase 1.6.1
+
+* Update all of the Gemfile(.lock) symlinks to actual file copies, for platform
+  compatibility
+* Stop including Gemfiles and lockfiles in the built gem.
+
 ## Release 1.6.0
 
 * Remove steep and the rbs types (#41)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    environment_helpers (1.6.0)
+    environment_helpers (1.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.ruby2.7.lock
+++ b/Gemfile.ruby2.7.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    environment_helpers (1.6.0)
+    environment_helpers (1.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.ruby3.0
+++ b/Gemfile.ruby3.0
@@ -1,1 +1,3 @@
-Gemfile
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.ruby3.0.lock
+++ b/Gemfile.ruby3.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    environment_helpers (1.6.0)
+    environment_helpers (1.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.ruby3.1
+++ b/Gemfile.ruby3.1
@@ -1,1 +1,3 @@
-Gemfile
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.ruby3.1.lock
+++ b/Gemfile.ruby3.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    environment_helpers (1.6.0)
+    environment_helpers (1.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.ruby3.2
+++ b/Gemfile.ruby3.2
@@ -1,1 +1,3 @@
-Gemfile
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.ruby3.2.lock
+++ b/Gemfile.ruby3.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    environment_helpers (1.6.0)
+    environment_helpers (1.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.ruby3.3
+++ b/Gemfile.ruby3.3
@@ -1,1 +1,3 @@
-Gemfile
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.ruby3.3.lock
+++ b/Gemfile.ruby3.3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    environment_helpers (1.6.0)
+    environment_helpers (1.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.ruby3.3.lock
+++ b/Gemfile.ruby3.3.lock
@@ -1,1 +1,137 @@
-Gemfile.lock
+PATH
+  remote: .
+  specs:
+    environment_helpers (1.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    ast (2.4.3)
+    chef-utils (18.7.10)
+      concurrent-ruby
+    coderay (1.1.3)
+    concurrent-ruby (1.3.5)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    git (1.19.1)
+      addressable (~> 2.8)
+      rchardet (~> 1.8)
+    git_diff_parser (4.0.0)
+    json (2.12.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    mdl (0.13.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
+    method_source (1.1.0)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
+      tomlrb
+    mixlib-shellout (3.3.9)
+      chef-utils
+    parallel (1.27.0)
+    parser (3.3.8.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (6.0.2)
+    quiet_quality (1.5.2)
+      git (>= 1.18)
+      git_diff_parser (~> 4)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rchardet (1.9.0)
+    regexp_parser (2.10.0)
+    rexml (3.4.1)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-cover_it (0.1.0)
+      rspec (~> 3.10)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.45.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-performance (1.23.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
+    standard (1.37.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.64.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.6.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.23.0)
+    tomlrb (2.0.3)
+    unicode-display_width (2.6.0)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  environment_helpers!
+  mdl (~> 0.13)
+  pry (~> 0.15)
+  quiet_quality (~> 1.5)
+  rspec (~> 3.13)
+  rspec-cover_it (~> 0.1.0)
+  rubocop (~> 1.63)
+  simplecov (~> 0.22.0)
+  standard (= 1.37.0)
+
+BUNDLED WITH
+   2.4.22

--- a/environment_helpers.gemspec
+++ b/environment_helpers.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`
       .split("\x0")
       .reject { |f| f.start_with?("spec") }
+      .reject { |f| f.start_with?("Gemfile") }
   end
 
   spec.bindir = "bin"

--- a/lib/environment_helpers/version.rb
+++ b/lib/environment_helpers/version.rb
@@ -1,3 +1,3 @@
 module EnvironmentHelpers
-  VERSION = "1.6.0"
+  VERSION = "1.6.1"
 end


### PR DESCRIPTION
`gem build` warned me about using symlinks, as they are not cross-platform compatible. I'm replacing all the symlinks with actual file copies, but _also_ excluding the Gemfiles and their locks from the built gem, since they can confuse security-scanners.

Bumping version to 1.6.1 for a release.