### PR TITLE
fix: correct typo in date_time required error message

### DIFF
--- a/lib/environment_helpers/datetime_helpers.rb
+++ b/lib/environment_helpers/datetime_helpers.rb
@@ -19,7 +19,7 @@ module EnvironmentHelpers
 
       return dt if dt
       return default unless required
-      fail(InvalidDateTimeText, "Require date_time environment variable #{name} had inappropriate content '#{text}'")
+      fail(InvalidDateTimeText, "Required date_time environment variable #{name} had inappropriate content '#{text}'")
     end
 
     private


### PR DESCRIPTION
Fixes #45

`"Require date_time..."` → `"Required date_time..."` in the error message raised when a required `date_time` variable has invalid content.