### PR TITLE
feat: support negative bounds in integer_range for dot formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ The available methods added to `ENV`:
   `N...N` (the latter excludes the upper bound, as in Ruby), and both formats
   support negative endpoints (e.g. `-5..10`, `-10..-3`). A dash-separated
   format `N-N` is also accepted, but only supports non-negative endpoints.
-* `integer` - produces an integer from the environment variable, by calling
-  `to_i` on it (if it's present). Note that this means that providing a value
-  like "hello" means you'll get `0`, since that's what ruby does when you call
-  `"hello".to_i`.
+* `integer` - produces an integer from the environment variable. Only values
+  matching `/\A-?\d+\z/` are accepted; anything else is treated as if the
+  variable were absent (returning `nil` or the default, or raising
+  `InvalidIntegerText` if `required: true`).
 * `file_path` - produces a `Pathname` initialized with the path specified by the
   environment variable.
 * `date` - produces a `Date` object, using `Date.strptime`. The default format

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ quickly.
 ## Installation
 
 ```ruby
-gem "environment_helper"
+gem "environment_helpers"
 ```
 
 There's not much to it - add the gem to your gemfile and when it's loaded it'll

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ The available methods added to `ENV`:
   value, though you should probably just use "true" and "false" really. If you
   specify `required: true` and get a value like "maybe?", it'll raise an
   `EnvironmentHelpers::InvalidBooleanText` exception.
-* `integer_range` - produces an integer Range object. It accepts `N-N`, `N..N`,
-  or `N...N`, (the latter means 'excluding the upper bound, as in ruby).
+* `integer_range` - produces an integer Range object. It accepts `N..N` or
+  `N...N` (the latter excludes the upper bound, as in Ruby), and both formats
+  support negative endpoints (e.g. `-5..10`, `-10..-3`). A dash-separated
+  format `N-N` is also accepted, but only supports non-negative endpoints.
 * `integer` - produces an integer from the environment variable, by calling
   `to_i` on it (if it's present). Note that this means that providing a value
   like "hello" means you'll get `0`, since that's what ruby does when you call

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ The available methods added to `ENV`:
   an allowed 'format'. But if it is supplied as a _string_, it will be handled
   as a strptime format string (the `:unix` format is equivalent to the format
   string `"%s"`). It handles invalid or unparseable values like `ENV.date` does,
-  in that they are treated as if not supplied.
+  in that they are treated as if not supplied. Note that an invalid format string
+  (e.g. one containing an unknown directive) is indistinguishable from a
+  non-matching value and will be silently treated the same way.
 * `array` - produces an array of strings, symbols, or integers, depending on the
   value of the `of` parameter. You can specify the delimiter using a `delimiter`
   parameter (it defaults to a comma).

--- a/lib/environment_helpers/range_helpers.rb
+++ b/lib/environment_helpers/range_helpers.rb
@@ -19,24 +19,16 @@ module EnvironmentHelpers
       fail(BadDefault, "Invalid endpoint for default range of #{context} - must be Integer")
     end
 
-    def parse_range_bound_from(text)
-      return nil if text.nil?
-      return nil if text.empty?
-      text.to_i
-    end
-
     def parse_range_from(text)
-      text =~ /\A(\d*)(-|\.\.|\.\.\.)(\d*)\z/
-      lower_bound = parse_range_bound_from($1)
-      separator = $2
-      upper_bound = parse_range_bound_from($3)
-
-      return nil if lower_bound.nil? || upper_bound.nil?
-      if separator == "..."
-        (lower_bound...upper_bound)
+      if text =~ /\A(-?\d+)(\.\.\.?)(-?\d+)\z/
+        lower_bound, separator, upper_bound = $1.to_i, $2, $3.to_i
+      elsif text =~ /\A(\d+)-(\d+)\z/
+        lower_bound, separator, upper_bound = $1.to_i, "..", $2.to_i
       else
-        (lower_bound..upper_bound)
+        return nil
       end
+
+      (separator == "...") ? (lower_bound...upper_bound) : (lower_bound..upper_bound)
     end
   end
 end

--- a/spec/environment_helpers/range_helpers_spec.rb
+++ b/spec/environment_helpers/range_helpers_spec.rb
@@ -113,6 +113,38 @@ RSpec.describe EnvironmentHelpers::RangeHelpers do
         with_env("FOO" => "3..")
         it { is_expected.to be_nil }
       end
+
+      context "with negative bounds" do
+        context "negative lower with two dots" do
+          with_env("FOO" => "-5..10")
+          it { is_expected.to eq((-5..10)) }
+        end
+
+        context "both negative with two dots" do
+          with_env("FOO" => "-10..-3")
+          it { is_expected.to eq((-10..-3)) }
+        end
+
+        context "negative upper with two dots" do
+          with_env("FOO" => "5..-3")
+          it { is_expected.to eq((5..-3)) }
+        end
+
+        context "negative lower with three dots" do
+          with_env("FOO" => "-5...0")
+          it { is_expected.to eq((-5...0)) }
+        end
+
+        context "negative lower with dash separator" do
+          with_env("FOO" => "-5-10")
+          it { is_expected.to be_nil }
+        end
+
+        context "negative upper with dash separator" do
+          with_env("FOO" => "5--3")
+          it { is_expected.to be_nil }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #46

Negative endpoints are now supported for the `..` and `...` formats (e.g. `-5..10`, `-10..-3`, `5..-3`). The dash-separated format remains positive-only. README updated to document both.